### PR TITLE
Update d4m-nfs.sh

### DIFF
--- a/d4m-nfs.sh
+++ b/d4m-nfs.sh
@@ -43,11 +43,13 @@ else
     sleep 0.5
   done
 
-  echo -ne "\nWait until D4M is running."
-  while ! $(ps auxwww|grep docker|grep vmstateevent |grep '"vmstate":"running"' > /dev/null 2>&1); do
-    echo -n "."
-    sleep 1
-  done
+# Docker VM is registering the running state differently at least in the latest version (Version 1.12.3-rc1-beta29 (13397))
+# Removing this check allows the script to fire without error.
+#  echo -ne "\nWait until D4M is running."
+#  while ! $(ps auxwww|grep docker|grep vmstateevent |grep '"vmstate":"running"' > /dev/null 2>&1); do
+#    echo -n "."
+#    sleep 1
+#  done
 
   # check that screen has not already been setup
   if ! $(screen -ls |grep d4m > /dev/null 2>&1); then


### PR DESCRIPTION
Commenting out command to wait until d4m is running as it is apparently being registered differently in the most recent version of docker (Version 1.12.3-rc1-beta29 (13397)). This is a workaround for issue #3
