### PR TITLE
Check if script is running under tmux

### DIFF
--- a/d4m-nfs.sh
+++ b/d4m-nfs.sh
@@ -8,10 +8,17 @@ while getopts ":q" opt; do
       README=false
       ;;
     \?)
-      echo "Invalid option: -$OPTARG" >&2
+      echo "[d4m-nfs] Invalid option: -$OPTARG" >&2
       ;;
   esac
 done
+
+# check if this script is running under tmux, and if so, exit
+# (under tmux, we are unable to attach to the d4m tty via screen)
+if { [ "$TERM" = "screen" ] && [ -n "$TMUX" ]; } then
+  echo "[d4m-nfs] This script cannot be run under tmux. Exiting."
+  exit 1
+fi
 
 # env var to specify whether we want our home bound to /mnt
 AUTO_MOUNT_HOME=${AUTO_MOUNT_HOME:-true}


### PR DESCRIPTION
**Problem**: 

When running under [tmux](https://tmux.github.io/), the script cannot create a `screen` session for the d4m tty to run the setup script on the moby vm. As a result, we loop on waiting for `d4m-done` to appear in `/tmp`, which will not occur since since the script was not started.

**Solution**:

Check if tmux is running via environment variables that it sets, and exit with status 1 if they are detected.

**Before**:
```
$ ./d4m-nfs.sh
[d4m-nfs] Copy the Moby VM APK Cache back.
[d4m-nfs] Create the script for Moby VM.
[d4m-nfs] Start and restop nfsd, for some reason restart is not as kind.
Stopping the nfsd service (use 'disable' to make permanent)
Starting the nfsd service
[d4m-nfs] Wait until NFS is setup..
[d4m-nfs] Wait until D4M is running.
[d4m-nfs] Setup 'screen' to work properly with the D4M tty, while at it name it 'd4m'.
[d4m-nfs] Run Moby VM d4m-nfs setup script.
No screen session found.
[d4m-nfs] Waiting until d4m-nfs setup is done...............................
```

**After**:
```
$ ./d4m-nfs.sh
[d4m-nfs] This script cannot be run under tmux. Exiting.
```