### PR TITLE
Match screen-256color as $TERM for tmux related exit

### DIFF
--- a/d4m-nfs.sh
+++ b/d4m-nfs.sh
@@ -14,8 +14,9 @@ while getopts ":q" opt; do
 done
 
 # check if this script is running under tmux, and if so, exit
+# tmux sets $TERM=screen or user sets $TERM=screen-256color
 # (under tmux, we are unable to attach to the d4m tty via screen)
-if { [ "$TERM" = "screen" ] && [ -n "$TMUX" ]; } then
+if { [[ "$TERM" =~ screen* ]] && [ -n "$TMUX" ]; } then
   echo "[d4m-nfs] This script cannot be run under tmux. Exiting."
   exit 1
 fi


### PR DESCRIPTION
From tmux's FAQ (https://github.com/tmux/tmux/blob/48a3dba6b9863abea9db47a2004009cb6cd68332/FAQ):

> Inside tmux TERM must be "screen" or similar (such as "screen-256color").

https://github.com/IFSight/d4m-nfs/pull/33 did not consider that users may also set `$TERM` to `screen-256color`.

This change will match both cases.

Currently, if `$TERM` is set to `screen-256color`, the script will proceed under tmux and fail as described in #33